### PR TITLE
[CI] Add a job to remove cache that would never be used

### DIFF
--- a/.github/workflows/garbageCollectCICache.yml
+++ b/.github/workflows/garbageCollectCICache.yml
@@ -1,0 +1,21 @@
+name: Garbage collect github CI cache that unlikely reused
+
+# Run every 4 hours
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 */4 * * *
+
+jobs:
+  run-script:
+    name: Check cache and remove 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check cache and remove
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Pretty print
+          gh cache list -k ccache-short-clang-Release-ON-ON -L 50
+          # Keep top 3 caches (in the case LLVM bump involved)
+          gh cache list -k ccache-short-clang-Release-ON-ON -L 50  --jq ".[3:]|.[].id" --json id | ./utils/delete-cache.sh

--- a/utils/delete-cache.sh
+++ b/utils/delete-cache.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+while read -r id; do
+  echo $id
+  # Turn on after making sure it works
+  # gh cache delete $id
+  sleep 2
+done


### PR DESCRIPTION
This PR adds a CI job that deletes caches created by short integrations tests. Almost 10GB is used by short integrations test. I think it's succifienct to have keep most recent one.

```
gh cache list -k ccache-short-clang-Release-ON-ON -L 50

Showing 27 of 27 caches in llvm/circt

ID     KEY                                         SIZE        CREATED               ACCESSED
66695  ccache-short-clang-Release-ON-ON-2024-0...  360.61 MiB  about 10 minutes ago  about 10 minutes ago
66694  ccache-short-clang-Release-ON-ON-2024-0...  360.33 MiB  about 15 minutes ago  about 15 minutes ago
66665  ccache-short-clang-Release-ON-ON-2024-0...  357.96 MiB  about 13 hours ago    about 22 minutes ago
66692  ccache-short-clang-Release-ON-ON-2024-0...  359.77 MiB  about 1 hour ago      about 1 hour ago
66675  ccache-short-clang-Release-ON-ON-2024-0...  354.45 MiB  about 8 hours ago     about 8 hours ago
66674  ccache-short-clang-Release-ON-ON-2024-0...  358.33 MiB  about 8 hours ago     about 8 hours ago
66673  ccache-short-clang-Release-ON-ON-2024-0...  359.41 MiB  about 8 hours ago     about 8 hours ago
66672  ccache-short-clang-Release-ON-ON-2024-0...  358.70 MiB  about 9 hours ago     about 8 hours ago
66667  ccache-short-clang-Release-ON-ON-2024-0...  358.85 MiB  about 11 hours ago    about 11 hours ago
66663  ccache-short-clang-Release-ON-ON-2024-0...  359.24 MiB  about 16 hours ago    about 13 hours ago
66664  ccache-short-clang-Release-ON-ON-2024-0...  381.06 MiB  about 13 hours ago    about 13 hours ago
66597  ccache-short-clang-Release-ON-ON-2024-0...  357.85 MiB  about 1 day ago       about 14 hours ago
66650  ccache-short-clang-Release-ON-ON-2024-0...  374.79 MiB  about 21 hours ago    about 16 hours ago
66661  ccache-short-clang-Release-ON-ON-2024-0...  376.57 MiB  about 17 hours ago    about 17 hours ago
66660  ccache-short-clang-Release-ON-ON-2024-0...  375.24 MiB  about 17 hours ago    about 17 hours ago
66659  ccache-short-clang-Release-ON-ON-2024-0...  377.82 MiB  about 17 hours ago    about 17 hours ago
66609  ccache-short-clang-Release-ON-ON-2024-0...  354.95 MiB  about 1 day ago       about 17 hours ago
66658  ccache-short-clang-Release-ON-ON-2024-0...  359.28 MiB  about 17 hours ago    about 17 hours ago
66651  ccache-short-clang-Release-ON-ON-2024-0...  358.97 MiB  about 20 hours ago    about 17 hours ago
66657  ccache-short-clang-Release-ON-ON-2024-0...  375.18 MiB  about 19 hours ago    about 19 hours ago
66656  ccache-short-clang-Release-ON-ON-2024-0...  364.31 MiB  about 20 hours ago    about 20 hours ago
66655  ccache-short-clang-Release-ON-ON-2024-0...  369.52 MiB  about 20 hours ago    about 20 hours ago
66654  ccache-short-clang-Release-ON-ON-2024-0...  363.87 MiB  about 20 hours ago    about 20 hours ago
66653  ccache-short-clang-Release-ON-ON-2024-0...  369.72 MiB  about 20 hours ago    about 20 hours ago
66652  ccache-short-clang-Release-ON-ON-2024-0...  374.89 MiB  about 20 hours ago    about 20 hours ago
66647  ccache-short-clang-Release-ON-ON-2024-0...  374.50 MiB  about 21 hours ago    about 21 hours ago
66649  ccache-short-clang-Release-ON-ON-2024-0...  361.49 MiB  about 21 hours ago    about 21 hours ago
```