### PR TITLE
 [CombToAIG] Add a lowering for AddOp

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -813,6 +813,11 @@ def ConvertCombToAIG: Pass<"convert-comb-to-aig",  "hw::HWModuleOp"> {
     "circt::comb::CombDialect",
     "circt::aig::AIGDialect",
   ];
+
+  let options = [
+    Option<"keepBitwiseLogicalOps", "keep-bitwise-logical-ops", "bool", "false",
+           "Keep bitwise logic in the output. This option is only used for testing">
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/integration_test/circt-synth/comb-lowering-lec.mlir
+++ b/integration_test/circt-synth/comb-lowering-lec.mlir
@@ -13,3 +13,10 @@ hw.module @bit_logical(in %arg0: i32, in %arg1: i32, in %arg2: i32, in %arg3: i3
 
   hw.output %0, %1, %2, %3 : i32, i32, i32, i32
 }
+
+// RUN: circt-lec %t.mlir %s -c1=add -c2=add --shared-libs=%libz3 | FileCheck %s --check-prefix=COMB_ADD
+// COMB_ADD: c1 == c2
+hw.module @add(in %arg0: i4, in %arg1: i4, in %arg2: i4,  out add: i4) {
+  %0 = comb.add %arg0, %arg1, %arg2 : i4
+  hw.output %0 : i4
+}

--- a/lib/Conversion/CombToAIG/CombToAIG.cpp
+++ b/lib/Conversion/CombToAIG/CombToAIG.cpp
@@ -26,6 +26,39 @@ using namespace circt;
 using namespace comb;
 
 //===----------------------------------------------------------------------===//
+// Utility Functions
+//===----------------------------------------------------------------------===//
+
+// Extract individual bits from a value
+static SmallVector<Value> extractBits(ConversionPatternRewriter &rewriter,
+                                      Value val) {
+  assert(val.getType().isInteger() && "expected integer");
+  auto width = val.getType().getIntOrFloatBitWidth();
+  SmallVector<Value> bits;
+  bits.reserve(width);
+
+  // Check if we can reuse concat operands
+  if (auto concat = val.getDefiningOp<comb::ConcatOp>()) {
+    if (concat.getNumOperands() == width &&
+        llvm::all_of(concat.getOperandTypes(), [](Type type) {
+          return type.getIntOrFloatBitWidth() == 1;
+        })) {
+      // Reverse the operands to match the bit order
+      bits.append(std::make_reverse_iterator(concat.getOperands().end()),
+                  std::make_reverse_iterator(concat.getOperands().begin()));
+      return bits;
+    }
+  }
+
+  // Extract individual bits
+  for (int64_t i = 0; i < width; ++i)
+    bits.push_back(
+        rewriter.createOrFold<comb::ExtractOp>(val.getLoc(), val, i, 1));
+
+  return bits;
+}
+
+//===----------------------------------------------------------------------===//
 // Conversion patterns
 //===----------------------------------------------------------------------===//
 
@@ -169,6 +202,68 @@ struct CombMuxOpConversion : OpConversionPattern<MuxOp> {
   }
 };
 
+struct CombAddOpConversion : OpConversionPattern<AddOp> {
+  using OpConversionPattern<AddOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(AddOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto inputs = adaptor.getInputs();
+    // Lower only when there are two inputs.
+    // Variadic operands must be lowered in a different pattern.
+    if (inputs.size() != 2)
+      return failure();
+
+    auto width = op.getType().getIntOrFloatBitWidth();
+    // Skip a zero width value.
+    if (width == 0) {
+      rewriter.replaceOpWithNewOp<hw::ConstantOp>(op, op.getType(), 0);
+      return success();
+    }
+
+    // Implement a naive Ripple-carry full adder.
+    Value carry;
+
+    auto aBits = extractBits(rewriter, inputs[0]);
+    auto bBits = extractBits(rewriter, inputs[1]);
+    SmallVector<Value> results;
+    results.resize(width);
+    for (int64_t i = 0; i < width; ++i) {
+      SmallVector<Value> xorOperands = {aBits[i], bBits[i]};
+      if (carry)
+        xorOperands.push_back(carry);
+
+      // sum[i] = xor(carry[i-1], a[i], b[i])
+      // NOTE: The result is stored in reverse order.
+      results[width - i - 1] =
+          rewriter.create<comb::XorOp>(op.getLoc(), xorOperands, true);
+
+      // If this is the last bit, we are done.
+      if (i == width - 1) {
+        break;
+      }
+
+      // carry[i] = (carry[i-1] & (a[i] ^ b[i])) | (a[i] & b[i])
+      Value nextCarry = rewriter.create<comb::AndOp>(
+          op.getLoc(), ValueRange{aBits[i], bBits[i]}, true);
+      if (!carry) {
+        // This is the first bit, so the carry is the next carry.
+        carry = nextCarry;
+        continue;
+      }
+
+      auto aXnorB = rewriter.create<comb::XorOp>(
+          op.getLoc(), ValueRange{aBits[i], bBits[i]}, true);
+      auto andOp = rewriter.create<comb::AndOp>(
+          op.getLoc(), ValueRange{carry, aXnorB}, true);
+      carry = rewriter.create<comb::OrOp>(op.getLoc(),
+                                          ValueRange{andOp, nextCarry}, true);
+    }
+
+    rewriter.replaceOpWithNewOp<comb::ConcatOp>(op, results);
+    return success();
+  }
+};
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -179,6 +274,8 @@ namespace {
 struct ConvertCombToAIGPass
     : public impl::ConvertCombToAIGBase<ConvertCombToAIGPass> {
   void runOnOperation() override;
+  using ConvertCombToAIGBase<ConvertCombToAIGPass>::ConvertCombToAIGBase;
+  using ConvertCombToAIGBase<ConvertCombToAIGPass>::keepBitwiseLogicalOps;
 };
 } // namespace
 
@@ -187,8 +284,11 @@ static void populateCombToAIGConversionPatterns(RewritePatternSet &patterns) {
       // Bitwise Logical Ops
       CombAndOpConversion, CombOrOpConversion, CombXorOpConversion,
       CombMuxOpConversion,
+      // Arithmetic Ops
+      CombAddOpConversion,
       // Variadic ops that must be lowered to binary operations
-      CombLowerVariadicOp<XorOp>>(patterns.getContext());
+      CombLowerVariadicOp<XorOp>, CombLowerVariadicOp<AddOp>>(
+      patterns.getContext());
 }
 
 void ConvertCombToAIGPass::runOnOperation() {
@@ -198,6 +298,11 @@ void ConvertCombToAIGPass::runOnOperation() {
   target.addLegalOp<comb::ExtractOp, comb::ConcatOp, comb::ReplicateOp,
                     hw::BitcastOp>();
   target.addLegalDialect<aig::AIGDialect>();
+
+  // This is a test only option to keep bitwise logical ops instead of lowering
+  // to AIG.
+  if (keepBitwiseLogicalOps)
+    target.addLegalOp<comb::MuxOp, comb::XorOp, comb::AndOp, comb::OrOp>();
 
   RewritePatternSet patterns(&getContext());
   populateCombToAIGConversionPatterns(patterns);


### PR DESCRIPTION
 This implements a pattern to lower AddOp to a naive ripple-carry adder.
 This PR also adds a test-only option to `keep-bitwise-logical-ops` to make
 testing easier.