### PR TITLE
Correct typo in README participation instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!--
+
+If AI tools were used, ensure this pull request complies with the
+[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
+including the requirements for human review, transparency, and accountability.
+
+Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.
+
+AI-assisted-by: <fill this in for substantial AI-generated content, e.g., "Claude Code: Opus 4.6">
+
+-->

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 "CIRCT" stands for "Circuit Intermediate Representations (IR) Compilers and Tools".  One might also interpret
 it as the recursively as "CIRCT IR Compiler and Tools".  The T can be
 selectively expanded as Tool, Translator, Team, Technology, Target, Tree, Type,
+
 ... we're ok with the ambiguity.
 
 The CIRCT community is an open and welcoming community.  If you'd like to

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ selectively expanded as Tool, Translator, Team, Technology, Target, Tree, Type,
 ... we're ok with the ambiguity.
 
 The CIRCT community is an open and welcoming community.  If you'd like to
-participate, you can do so in a number of different ways:
+participate, you can do so in a number of differen
+t ways:
 
 1) Join our [Discourse Forum](https://llvm.discourse.group/c/Projects-that-want-to-become-official-LLVM-Projects/circt/) 
 on the LLVM Discourse server.  To get a "mailing list" like experience click the 


### PR DESCRIPTION
Fix typographical error in participation section.

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

AI-assisted-by: <fill this in for substantial AI-generated content, e.g., "Claude Code: Opus 4.6">

-->
